### PR TITLE
map docker uid to external one during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,11 @@ RUN python setup.py install
 RUN ldconfig
 
 # adding a user to run the bot from
-ENV USER="user"
-ENV HOME="/home/${USER}"
-RUN useradd -ms /bin/bash $USER
-USER $USER
+ARG TARGET_USER="user"
+ARG TARGET_UID="1000"
+ARG HOME="/home/${TARGET_USER}"
+RUN useradd -u $TARGET_UID -ms /bin/bash $TARGET_USER
+USER $TARGET_USER
 WORKDIR $HOME
 
 # clonning the bot repo and installing all the requirements
@@ -27,5 +28,9 @@ RUN pip install --user -r requirements.txt
 
 # copy configuration file you've preliminarily prepared
 ADD config.py ./
+USER root
+RUN chown $TARGET_UID:$TARGET_UID ./config.py
+RUN chmod 600 ./config.py
+USER $TARGET_USER
 
 CMD python main.py -l INFO

--- a/README.md
+++ b/README.md
@@ -71,11 +71,10 @@ That's basically it.
 ## With Docker
 
 ```
-mkdir ~/.delator
-chmod -R a+w ~/.delator
+docker build -t delator --build-arg NO_CACHE="`date`" --build-arg TARGET_UID=$(id -u) --build_arg TARGET_USER=$(id -u -n) .
 
-docker build -t delator --build-arg NO_CACHE="`date`" .
-docker run -v ~/.delator/:/home/user/delator/profile -it delator
+mkdir ~/.delator
+docker run -v ~/.delator/:/home/$(id -u -n)/delator/profile -it delator
 ```
 
 # Add a command


### PR DESCRIPTION
Use `build-arg` in `docker build` to pass uid to use inside docker in order to fix permission issues.